### PR TITLE
Fix memory consumption issues

### DIFF
--- a/src/epochraft_hf_fsdp/fsdp.py
+++ b/src/epochraft_hf_fsdp/fsdp.py
@@ -87,7 +87,6 @@ def setup_fsdp(
             buffer_dtype=torch.bfloat16,
             cast_forward_inputs=True,
         ),
-        forward_prefetch=True,
         limit_all_gathers=True,
     )
 

--- a/src/epochraft_hf_fsdp/trainer.py
+++ b/src/epochraft_hf_fsdp/trainer.py
@@ -112,6 +112,7 @@ class Trainer:
             torch_dtype=torch.bfloat16,
             trust_remote_code=True,
             use_flash_attention_2=True,
+            use_cache=False,
         )
         num_params = get_num_params(model)  # Need to do this before FSDP
         layer_cls = fsdp.get_transformer_block_class(model, config.transformer_blocks_path)


### PR DESCRIPTION
It was pointed out that GPU memory usage of this codebase was slightly high. Specifically, when training Llama-2 7B with 16 X 40GB GPUs, OoM errors occurred with a micro batchsize of 8. However, in a similar codebase `llama-recipes`, the same setting does not cause an OoM error.

The key solution was to set `use_cache=False` in `from_pretrained`. With this change, the aforementioned configuration worked successfully. Additionally, `forward_prefetch=True` is removed in this PR, which slightly reduces memory usage. This had a minimal impact on speed and was not used in `llama-recipes` either.

The configuration used to verify was as follows:

<details>
```
wandb:
  url: https://stability.wandb.io
  entity: null
  project: epochraft-hf-fsdp
  name: llama2-7b_testrun

trainer:
  load_dir: null
  save_dir: ./out/gpt2_testrun

  model: meta-llama/Llama-2-7b-hf
  transformer_blocks_path: model.layers
  fsdp_sharding_strategy: FULL_SHARD
  # fsdp_cpu_offload: false

  seq_len: 4096
  global_batch_size: 128
  micro_batch_size: 8
  steps: 100

  ckpt_steps: 50
  val_steps: 20

  zerolr_warmup_steps: 5
  linear_warmup_steps: 10
  cooldown_steps: 10
  max_lr: 0.0001
  min_lr: 0.00001
  weight_decay: 0.1
  grad_clip: 1.0
  beta1: 0.9
  beta2: 0.95
  eps: 0.000001

tokenizer: null

val_samples: 64
val_dataset:
  - name: GitHub
    url: https://data.together.xyz/redpajama-data-1T/v1.0.0/github/filtered_08cdfa755e6d4d89b673d5bd1acee5f6.sampled.jsonl
  - name: ArXiv
    url: https://data.together.xyz/redpajama-data-1T/v1.0.0/arxiv/arxiv_023827cd-7ee8-42e6-aa7b-661731f4c70f.jsonl
  - name: C4
    url: https://data.together.xyz/redpajama-data-1T/v1.0.0/c4/c4-train.00000-of-01024.jsonl

train_dataset:
- name: GitHub
  weight: 1
  urls:
  - https://data.together.xyz/redpajama-data-1T/v1.0.0/github/filtered_0f27d10d846a473b96070c3394832f32.sampled.jsonl
  - https://data.together.xyz/redpajama-data-1T/v1.0.0/github/filtered_0f979046c8e64e0fb5843d2634a9957d.sampled.jsonl
  - https://data.together.xyz/redpajama-data-1T/v1.0.0/github/filtered_10f129bfd0af45caa9cd72aa9d863ec5.sampled.jsonl
  - https://data.together.xyz/redpajama-data-1T/v1.0.0/github/filtered_11a1943edfa349c7939382799599eed6.sampled.jsonl
  - https://data.together.xyz/redpajama-data-1T/v1.0.0/github/filtered_17197bd2478044bebd9ff4634b6dfcee.sampled.jsonl
  - https://data.together.xyz/redpajama-data-1T/v1.0.0/github/filtered_1d750c0ce39d40c6bc20bad9469e5a99.sampled.jsonl
  - https://data.together.xyz/redpajama-data-1T/v1.0.0/github/filtered_21078cf63afb4d9eb4a7876f726a7226.sampled.jsonl
  - https://data.together.xyz/redpajama-data-1T/v1.0.0/github/filtered_216883d3a669406699428bc485a4c228.sampled.jsonl
- name: ArXiv
  weight: 1
  urls:
  - https://data.together.xyz/redpajama-data-1T/v1.0.0/arxiv/arxiv_024de5df-1b7f-447c-8c3a-51407d8d6732.jsonl
  - https://data.together.xyz/redpajama-data-1T/v1.0.0/arxiv/arxiv_03232e26-be3f-4a28-a5d2-ee1d8c0e9831.jsonl
  - https://data.together.xyz/redpajama-data-1T/v1.0.0/arxiv/arxiv_034e819a-cfcb-43c6-ad25-0232ad48823c.jsonl
  - https://data.together.xyz/redpajama-data-1T/v1.0.0/arxiv/arxiv_077ae8de-a68e-47e7-95a6-6d82f8f4eeb9.jsonl
  - https://data.together.xyz/redpajama-data-1T/v1.0.0/arxiv/arxiv_0af50072-df4c-4084-a833-cebbd046e70e.jsonl
  - https://data.together.xyz/redpajama-data-1T/v1.0.0/arxiv/arxiv_0de84cfc-c080-471f-b139-1bf061db4feb.jsonl
  - https://data.together.xyz/redpajama-data-1T/v1.0.0/arxiv/arxiv_0fbdd8ad-32d8-4228-9a40-e09dde689760.jsonl
  - https://data.together.xyz/redpajama-data-1T/v1.0.0/arxiv/arxiv_11c659c1-ffbf-4455-abfd-058f6bbf4bb2.jsonl
```
</details>